### PR TITLE
Upgrade Thrift to ~0.9.1

### DIFF
--- a/lib/scribe.js
+++ b/lib/scribe.js
@@ -87,7 +87,7 @@ util.inherits(Scribe, events.EventEmitter);
 Scribe.prototype.open = function(callback) {
   var self = this;
   this.opened = true;
-  this.connection = thrift.createConnection(this.host, this.port);
+  this.connection = thrift.createConnection(this.host, this.port, {transport: thrift.TFramedTransport});
   this.client = thrift.createClient(scribe, this.connection);
 
   this.connection.once('error', function(err) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/Applifier/node-scribe"
   },
   "dependencies": {
-    "thrift" : "0.7.0"
+    "thrift": "~0.9.1"
   },
   "author": "Applifier <opensource@applifier.com>"
 }


### PR DESCRIPTION
This fixes a unicode issue
