### PR TITLE
support batch sending and logging & refactor tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TESTS = $(shell find . -name "*.test.js")
 
 test:
-	@mocha -u tdd --globals "encoding" -t 8000 $(TESTS) -R spec
+	@./node_modules/.bin/mocha -u tdd --globals "encoding" -t 8000 $(TESTS) -R spec
 
 
 .PHONY: test

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -69,7 +69,7 @@ var Logger = exports.Logger = function (scribe, category) {
   }
 
   this.stackRegex = new RegExp("Error.+?\t.+?\t.+?\t +?at (.+?)\t");
-  this.lastLoggedLeve = null;
+  this.lastLoggedLevel = null;
   this.lastLoggedLine = null;
 
   this.scribe = scribe;
@@ -172,6 +172,25 @@ Logger.prototype.logMessage = function (level, msg) {
     process.stdout.write(this.levelNames[level] + "\t" + process.pid + "\t" + this.extractCalledFromStack() + "\t" + msg + "\n");
   }
 
+};
+
+Logger.prototype.logMessages = function (level, msgs) {
+  var prefix = this.levelNames[level] + "\t" + this.hostname + "\t" + process.pid + "\t" + this.extractCalledFromStack() + "\t";
+
+  this.lastLoggedLevel = level;
+  this.lastLoggedLine = prefix + "\t" + msgs[msgs.length - 1];
+
+  var logs = [];
+  for (var i = 0, len = msgs.length; i < len; i++) {
+    if (this.scribe) {
+      logs.push(this.formatTimestamp(new Date()) + "\t" + prefix + "\t" + msgs[i]);
+    } else {
+      process.stdout.write(this.levelNames[level] + "\t" + process.pid + "\t" + this.extractCalledFromStack() + "\t" + msgs[i] + "\n");
+    }
+  }
+  if (logs.length > 0) {
+    this.scribe.send(this.scribeCategory, logs);
+  }
 };
 
 Logger.prototype.debug = Logger.prototype.log = function (msg) {

--- a/lib/scribe.js
+++ b/lib/scribe.js
@@ -191,14 +191,18 @@ Scribe.prototype.retryConnection = function() {
 /**
  * Send log entry to scribe server
  @param {String} category Log category
- @param {String} message Log message
+ @param {String|Array} message Log message
  */
-Scribe.prototype.send = function(category, message) {
-  var entry = new scribe_types.LogEntry({
-    category : category,
-    message : message
-  });
+Scribe.prototype.send = function(category, messages) {
+  if (messages.constructor !== Array) {
+    messages = [messages];
+  }
+  for (var i = 0, len = messages.length; i < len; i++) {
+    this.queue.push(new scribe_types.LogEntry({
+      category : category,
+      message : messages[i]
+    }));
+  }
 
-  this.queue.push(entry);
   this.flush();
 };

--- a/package.json
+++ b/package.json
@@ -2,12 +2,18 @@
   "name": "scribe",
   "description": "Scribe client",
   "version": "0.0.10",
+  "scripts": {
+    "test": "make test"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/Applifier/node-scribe"
   },
   "dependencies": {
-    "thrift" : "0.7.0"
+    "thrift": "0.7.0"
   },
-  "author": "Applifier <opensource@applifier.com>"
+  "author": "Applifier <opensource@applifier.com>",
+  "devDependencies": {
+    "mocha": "^2.4.5"
+  }
 }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -3,49 +3,83 @@ var Scribe = require('../lib/scribe').Scribe;
 var scribeServer = require('../test_utils/scribeserver');
 var Logger = require('../lib/logger').Logger;
 
-module.exports = {
-  'test construct': function() {
-    var scribe = new Scribe("localhost", 8988);
-    var logger = new Logger(scribe, "foo");
-  },
-  'test sending data' : function() {
-    var server = scribeServer.createServer();
-    server.on('log', function(entry) {
-      assert.equal(entry.length, 1, "Should have received one entry");
-      assert.equal(entry[0].category, "foo");
-      assert.ok(entry[0].message.indexOf("\tfoobar") > -1);
-      assert.ok(entry[0].message.indexOf("\tDEBUG") > -1);
-      setTimeout(function() {
-        scribe.close();
-        server.close();
-      }, 500);
-    });
-    server.listen(8992);
-    var scribe = new Scribe("localhost", 8992);
-    var logger = new Logger(scribe, "foo");
-    scribe.open(function(err, client) {
-      logger.log("foobar");
-    });
-  },
-  'test replacing console' : function() {
-    var server = scribeServer.createServer();
-    server.on('log', function(entry) {
-      assert.equal(entry.length, 1, "Should have received one entry");
-      assert.equal(entry[0].category, "foo");
-      assert.ok(entry[0].message.indexOf("\tfoobar") > -1);
-      assert.ok(entry[0].message.indexOf("\tDEBUG") > -1);
-      setTimeout(function() {
-        scribe.close();
-        server.close();
-      }, 500);
-    });
-    server.listen(8993);
-    var scribe = new Scribe("localhost", 8993);
-    var logger = new Logger(scribe, "foo");
-    logger.replaceConsole();
-    scribe.open(function(err, client) {
-      console.log("foobar");
-      logger.releaseConsole();
-    });
-  }
-};
+test('test construct', function(done) {
+  var scribe = new Scribe("localhost", 8988);
+  var logger = new Logger(scribe, "foo");
+  assert.ok(scribe);
+  assert.ok(logger);
+  done();
+});
+
+test('test sending data', function(done) {
+  var server = scribeServer.createServer();
+  server.on('log', function(entry) {
+    assert.equal(entry.length, 1, "Should have received one entry");
+    assert.equal(entry[0].category, "foo");
+    assert.ok(entry[0].message.indexOf("\tfoobar") > -1);
+    assert.ok(entry[0].message.indexOf("\tDEBUG") > -1);
+    setTimeout(function() {
+      scribe.close();
+      server.close();
+      done();
+    }, 500);
+  });
+  server.listen(8992);
+  var scribe = new Scribe("localhost", 8992);
+  var logger = new Logger(scribe, "foo");
+  scribe.open(function(err, client) {
+    logger.log("foobar");
+  });
+});
+
+test('test batch sending data', function(done) {
+  var server = scribeServer.createServer();
+  server.on('log', function(entry) {
+    assert.equal(entry.length, 6, "Should have received six entries");
+    assert.equal(entry[0].category, "foo");
+    assert.ok(entry[0].message.indexOf("\tfoobar") > -1);
+    assert.ok(entry[0].message.indexOf("\tDEBUG") > -1);
+    setTimeout(function() {
+      scribe.close();
+      server.close();
+      done();
+    }, 500);
+  });
+  server.listen(8992);
+  var scribe = new Scribe("localhost", 8992);
+  var logger = new Logger(scribe, "foo");
+  scribe.open(function(err, client) {
+    logger.logMessages(Logger.LOG_DEBUG, [
+      "foobar1",
+      "foobar2",
+      "foobar3",
+      "foobar4",
+      "foobar5",
+      "foobar6"
+    ]);
+  });
+});
+
+test('test replacing console', function(done) {
+  var server = scribeServer.createServer();
+  server.on('log', function(entry) {
+    process.stdout.write('@log' + JSON.stringify(entry) + '\n');
+    assert.equal(entry.length, 1, "Should have received one entry");
+    assert.equal(entry[0].category, "foo");
+    assert.ok(entry[0].message.indexOf("\tfoobar") > -1);
+    assert.ok(entry[0].message.indexOf("\tDEBUG") > -1);
+    setTimeout(function() {
+      scribe.close();
+      server.close();
+      done();
+    }, 500);
+  });
+  server.listen(8993);
+  var scribe = new Scribe("localhost", 8993);
+  var logger = new Logger(scribe, "foo");
+  logger.replaceConsole();
+  scribe.open(function(err, client) {
+    console.log("foobar");
+    logger.releaseConsole();
+  });
+});

--- a/test/requestlog.test.js
+++ b/test/requestlog.test.js
@@ -2,37 +2,26 @@ var RequestLog = require('../lib/requestlog');
 var assert = require('assert');
 
 test("constructor", function(done) {
-
   assert.ok(RequestLog);
-
   done();
 });
-
 
 test("creates request id", function(done) {
-
   var req = {};
   var res = {};
-
   var middleware = RequestLog.factory();
-
   assert.ok(middleware != null);
-
   done();
 });
 
-
 test("can log something", function(done) {
-
   var req = {};
   var res = {};
   var buf = "";
 
   RequestLog.factory(function (level, id, line, msg) {
       buf += msg;
-      })(req, res, function() {});
-
-
+    })(req, res, function() {});
 
   req.log.log("test");
 
@@ -42,7 +31,6 @@ test("can log something", function(done) {
 });
 
 test("can figure out caller line", function(done) {
-
   var req = {};
   var res = {};
   var buf = "";
@@ -53,24 +41,21 @@ test("can figure out caller line", function(done) {
       buf += msg;
     })(req, res, function() {});
 
-
   req.log.log("test");
 
   assert.equal(buf, "test");
-  assert.equal(line, "Test.fn (/Users/juhomakinen/Development/node-scribe/test/requestlog.test.js:57:11)");
+  assert(line.indexOf("test/requestlog.test.js:44:11") > -1);
 
   done();
 });
 
 test("can pass level correctly", function(done) {
-
   var req = {};
   var res = {};
   var levels = [];
 
-
   RequestLog.factory(function (level, id, _line, msg) {
-    levels.push(level);
+      levels.push(level);
     })(req, res, function() {});
 
   req.log.log("test");
@@ -78,7 +63,6 @@ test("can pass level correctly", function(done) {
   req.log.warn("test");
   req.log.error("test");
   req.log.critical("test");
-
 
   assert.equal(levels[0], 7);
   assert.equal(levels[1], 6);
@@ -90,20 +74,15 @@ test("can pass level correctly", function(done) {
 });
 
 test("can has unique id", function(done) {
-
   var req = {};
   var res = {};
   var levels = [];
 
-
   RequestLog.factory(function (level, id, _line, msg) {
-    levels.push(level);
+      levels.push(level);
     })(req, res, function() {});
-
-
 
   assert.ok(req.log.id);
 
   done();
 });
-

--- a/test/scribe.test.js
+++ b/test/scribe.test.js
@@ -2,61 +2,88 @@ var assert = require('assert');
 var Scribe = require('../lib/scribe').Scribe;
 var scribeServer = require('../test_utils/scribeserver');
 
+test('test construct', function(done) {
+  var scribe = new Scribe("localhost", 8988);
+  assert.ok(scribe);
+  done();
+});
 
-module.exports = {
-  'test construct': function() {
-    var scribe = new Scribe("localhost", 8988);
-  },
-  'test connection opening' : function() {
-    var server = scribeServer.createServer();
-    server.listen(8988);
-    var scribe = new Scribe("localhost", 8988);
-    scribe.open(function(err, client) {
+test('test connection opening', function(done) {
+  var server = scribeServer.createServer();
+  server.listen(8988);
+  var scribe = new Scribe("localhost", 8988);
+  scribe.open(function(err) {
+    assert.ok(scribe.opened);
+    scribe.close();
+    assert.ok(!scribe.opened);
+    setTimeout(function() {
+      server.close();
+      done();
+    }, 500);
+  });
+});
+
+test('test sending data', function(done) {
+  var server = scribeServer.createServer();
+  server.on('log', function(entry) {
+    assert.equal(entry.length, 1, "Should have received one entry");
+    assert.equal(entry[0].category, "foogroup");
+    assert.equal(entry[0].message, "barmessage");
+    setTimeout(function() {
       scribe.close();
-      setTimeout(function() {
-        server.close();
-      }, 500);
-    });
+      server.close();
+      done();
+    }, 500);
+  });
+  server.listen(8989);
+  var scribe = new Scribe("localhost", 8989);
+  scribe.open(function(err, client) {
+    scribe.send("foogroup", "barmessage");
+  });
+});
 
-  },
-  'test sending data' : function() {
-    var server = scribeServer.createServer();
-    server.on('log', function(entry) {
-      assert.equal(entry.length, 1, "Should have received one entry");
-      assert.equal(entry[0].category, "foogroup");
-      assert.equal(entry[0].message, "barmessage");
-      setTimeout(function() {
-        scribe.close();
-        server.close();
-      }, 500);
-    });
-    server.listen(8989);
-    var scribe = new Scribe("localhost", 8989);
-    scribe.open(function(err, client) {
-      scribe.send("foogroup", "barmessage");
+test('test batch sending data', function(done) {
+  var server = scribeServer.createServer();
+  server.on('log', function(entry) {
+    assert.equal(entry.length, 6, "Should have received 6 entries");
+    setTimeout(function() {
+      scribe.close();
+      server.close();
+      done();
+    }, 500);
+  });
+  server.listen(8990);
+  var scribe = new Scribe("localhost", 8990);
+  scribe.open(function(err, client) {
+    scribe.send("foogroup", [
+      "barmessage1",
+      "barmessage2",
+      "barmessage3",
+      "barmessage4",
+      "barmessage5",
+      "barmessage6",
+    ]);
+  });
+});
 
-    });
-  },
-  'test queuing data' : function() {
-    var server = scribeServer.createServer();
-    server.on('log', function(entry) {
-      assert.equal(entry.length, 6, "Should have received 6 entries");
-      setTimeout(function() {
-        scribe.close();
-        server.close();
-      }, 500);
-    });
-    server.listen(8990);
-    var scribe = new Scribe("localhost", 8990);
-    scribe.send("foogroup1", "barmessage");
-    scribe.send("foogroup2", "barmessage");
-    scribe.send("foogroup3", "barmessage");
-    scribe.send("foogroup4", "barmessage");
-    scribe.send("foogroup5", "barmessage");
-    scribe.send("foogroup6", "barmessage");
-    scribe.open(function(err, client) {
-
-
-    });
-  }
-};
+test('test queuing data', function(done) {
+  console.log('@test queue');
+  var server = scribeServer.createServer();
+  server.on('log', function(entry) {
+    assert.equal(entry.length, 6, "Should have received 6 entries");
+    setTimeout(function() {
+      scribe.close();
+      server.close();
+      done();
+    }, 500);
+  });
+  server.listen(8990);
+  var scribe = new Scribe("localhost", 8990);
+  scribe.send("foogroup1", "barmessage");
+  scribe.send("foogroup2", "barmessage");
+  scribe.send("foogroup3", "barmessage");
+  scribe.send("foogroup4", "barmessage");
+  scribe.send("foogroup5", "barmessage");
+  scribe.send("foogroup6", "barmessage");
+  scribe.open(function(err, client) {});
+});


### PR DESCRIPTION
our app may flush tons of messages in a very short period, so batch processing is reasonable. Changes are:
- extends `Scribe.prototype.send(category, message)` to `Scribe.prototype.send(category, messages)`, if messages is not `Array` it will be converted to `Array`
- add `Logger.prototype.logMessages(level, msgs)`, which internally call `Scribe.prototype.send(category, messages)`
- refactor tests
